### PR TITLE
Fix qrcode-pix import error

### DIFF
--- a/base/backend/src/routes/index.js
+++ b/base/backend/src/routes/index.js
@@ -2,7 +2,9 @@ import { Router } from "express";
 import { prisma } from "../prisma.js";
 import { tenantResolver } from "../middlewares/tenantResolver.js";
 import { geoMessage } from "../middlewares/geoMessage.js";
-import { QRCodePix } from "qrcode-pix";
+import pkg from "qrcode-pix";
+
+const { QrCodePix } = pkg;
 
 const router = Router();
 
@@ -54,7 +56,7 @@ router.get("/payment/pix/:productId", tenantResolver, async (req, res, next) => 
     }
 
     const value = Number(product.price);
-    const pix = QRCodePix({
+    const pix = QrCodePix({
       version: "01",
       key: tenant.pix_key,
       name: tenant.name.substring(0, 25),


### PR DESCRIPTION
Corrects `qrcode-pix` import to resolve `SyntaxError: Named export 'QRCodePix' not found`.

The `qrcode-pix` module is a CommonJS module, requiring a default import and destructuring (`import pkg from 'qrcode-pix'; const { QrCodePix } = pkg;`) instead of a direct named import. The correct export name is `QrCodePix` (camelCase), not `QRCodePix`.

---
<a href="https://cursor.com/background-agent?bcId=bc-dffd286e-afce-49e9-ab2d-de1b34153140">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dffd286e-afce-49e9-ab2d-de1b34153140">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

