### PR TITLE
Fix prisma migrations in railway deploy

### DIFF
--- a/base/backend/Procfile
+++ b/base/backend/Procfile
@@ -1,1 +1,1 @@
-web: node src/index.js
+web: npm start

--- a/base/backend/package.json
+++ b/base/backend/package.json
@@ -27,10 +27,10 @@
     "qrcode": "^1.5.4",
     "qrcode-pix": "^2.0.4",
     "request-ip": "^3.3.0",
-    "mercadopago": "^2.2.6"
+    "mercadopago": "^2.2.6",
+    "prisma": "^5.16.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.0",
-    "prisma": "^5.16.1"
+    "nodemon": "^3.1.0"
   }
 }


### PR DESCRIPTION
Enable Prisma migrations during Railway deployment by ensuring `npm start` is used and Prisma is a production dependency.

The `Procfile` change to `web: npm start` ensures the `prestart` script (which runs `prisma migrate deploy` or `db push`) is executed. Moving `prisma` to `dependencies` makes the CLI available in production.

---
<a href="https://cursor.com/background-agent?bcId=bc-4452432b-17f9-4e6d-a034-784091c59cb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4452432b-17f9-4e6d-a034-784091c59cb1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

