### PR TITLE
Fix admin-frontend build type error

### DIFF
--- a/base/admin-frontend/src/app/layout.tsx
+++ b/base/admin-frontend/src/app/layout.tsx
@@ -21,7 +21,7 @@ function Nav() {
   );
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: Parameters<typeof Providers>[0]["children"] }) {
   return (
     <html lang="pt-BR">
       <body>

--- a/base/admin-frontend/src/app/providers.tsx
+++ b/base/admin-frontend/src/app/providers.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode, useState } from "react";
+import { useState, type ComponentProps } from "react";
 
-export function Providers({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+export function Providers({ children }: { children: ComponentProps<typeof QueryClientProvider>["children"] }) {
+	const [queryClient] = useState(() => new QueryClient());
+	return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }


### PR DESCRIPTION
Update `children` prop types in `providers.tsx` and `layout.tsx` to resolve a React type mismatch build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd446b81-d0c6-4531-883f-85e3abeefdea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd446b81-d0c6-4531-883f-85e3abeefdea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

